### PR TITLE
Improve Bluetooth/ANT+ startup handling, CSC event timestamps, and adapter mapping

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -86,7 +86,9 @@ export class App {
     this.kinematics = { // Maintain cumulative wheel/crank state for CSC notifications.
       lastTimestamp: null, // Last time we integrated cadence/speed samples.
       crankRevolutions: 0, // Floating-point accumulator for crank revolutions so we can wrap at 16 bits cleanly.
-      wheelRevolutions: 0 // Floating-point accumulator for wheel revolutions (32-bit field in BLE spec).
+      wheelRevolutions: 0, // Floating-point accumulator for wheel revolutions (32-bit field in BLE spec).
+      lastCrankEventTimestamp: 0, // BLE "last crank event time" should only advance when a new crank revolution is observed.
+      lastWheelEventTimestamp: 0 // BLE "last wheel event time" should only advance when a new wheel revolution is observed.
     };
     this.crank = { timestamp: 0, revolutions: 0 }; // BLE-friendly crank snapshot (16-bit revolutions + seconds timestamp).
     this.wheel = { timestamp: 0, revolutions: 0 }; // BLE-friendly wheel snapshot (32-bit revolutions + seconds timestamp).
@@ -469,6 +471,7 @@ export class App {
       if (state === 'poweredOn') {
         return;
       }
+      let shouldReinitialize = false; // Track whether this attempt should force a noble reinit/fallback adapter hop.
       
       // Teaching note: If adapter is UP at OS level but noble reports unknown,
       // verify scan usability before proceeding; some stacks still fail scans.
@@ -479,34 +482,42 @@ export class App {
           this.logger.log('[gym-app] proceeding despite noble state mismatch (scan probe succeeded)');
           return;
         }
-        this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is up but scan probe failed; proceeding in degraded mode to avoid noble reinit bind race`);
-        return;
+        this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP but scan probe failed; reinitializing noble instead of proceeding in degraded mode`);
+        shouldReinitialize = true;
       }
       
-      this.logger.log(`[gym-app] waiting for Bluetooth adapter to become poweredOn (attempt ${attempt}/${maxAttempts}, current state: ${state})`);
-      try {
-        const nextState = await this.waitForNobleStateChange(timeoutMs);
-        if (nextState === 'poweredOn') {
-          return;
-        }
-        this.logger.log(`[gym-app] Bluetooth adapter state is ${nextState}; reinitializing noble`);
-      } catch (error) {
-        this.logger.log(`[gym-app] Bluetooth adapter state timeout after ${timeoutMs}ms; checking if adapter is up...`);
-        
-        // If adapter is up, only continue if a probe scan succeeds.
-        if (this.isAdapterUp(this.opts.bikeAdapter)) {
-          const canScan = await this.probeNobleScan(this.opts.bikeAdapter);
-          if (canScan) {
-            this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP (hciconfig confirms); proceeding despite noble state being ${state}`);
+      if (!shouldReinitialize) {
+        this.logger.log(`[gym-app] waiting for Bluetooth adapter to become poweredOn (attempt ${attempt}/${maxAttempts}, current state: ${state})`);
+        try {
+          const nextState = await this.waitForNobleStateChange(timeoutMs);
+          if (nextState === 'poweredOn') {
             return;
           }
-          this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP but scan probe failed; proceeding in degraded mode to avoid noble reinit bind race`);
-          return;
+          this.logger.log(`[gym-app] Bluetooth adapter state is ${nextState}; reinitializing noble`);
+          shouldReinitialize = true;
+        } catch (error) {
+          this.logger.log(`[gym-app] Bluetooth adapter state timeout after ${timeoutMs}ms; checking if adapter is up...`);
+          
+          // If adapter is up, only continue if a probe scan succeeds.
+          if (this.isAdapterUp(this.opts.bikeAdapter)) {
+            const canScan = await this.probeNobleScan(this.opts.bikeAdapter);
+            if (canScan) {
+              this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP (hciconfig confirms); proceeding despite noble state being ${state}`);
+              return;
+            }
+            this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP but scan probe failed; forcing noble reinit`);
+            shouldReinitialize = true;
+          } else {
+            this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is not responding; reinitializing noble`);
+            shouldReinitialize = true;
+          }
         }
-        
-        this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is not responding; reinitializing noble`);
       }
-      
+
+      if (!shouldReinitialize) {
+        continue; // Defensive: if we somehow got here without a reason to reinit, start the next probe attempt.
+      }
+
       const fallback = fallbackAdapters[fallbackIndex];
       if (fallback) {
         fallbackIndex += 1;
@@ -517,6 +528,9 @@ export class App {
         await this.reinitializeNoble(`fallback-${attempt}`);
       } else {
         await this.reinitializeNoble(`attempt-${attempt}`);
+      }
+      if (this.noble?.state === 'poweredOn') {
+        return; // No need to sleep/retry when reinit already recovered the adapter.
       }
       await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
@@ -735,6 +749,8 @@ export class App {
       const retryDelayMs = Math.max(this.minimumRetryDelayMs, Number(this.opts.connectionRetryDelay ?? sharedDefaults.connectionRetryDelay ?? 5000)); // Guarantee a sensible retry floor in production while allowing tests to override it.
       const serverAdapterLabel = this.serverAdapters?.length ? this.serverAdapters.join(',') : this.opts.serverAdapter;
       this.logger.log(`[gym-app] startup opts: bike=${this.opts.bike} defaultBike=${this.opts.defaultBike} bikeAdapter=${this.opts.bikeAdapter} serverAdapter=${serverAdapterLabel}`);
+      this.logger.log(`[gym-app] ANT+ mode: ${this.antEnabled ? 'enabled (USB ANT stick transport)' : 'disabled'}`); // ANT+ transport is independent from BLE adapter selection.
+      this.logRadioMap(); // Emit one compact "which radio does what" line for Pi troubleshooting.
 
       while (this.keepRunning) { // Keep looping until shutdown or we successfully complete the full startup sequence.
         try {
@@ -957,14 +973,26 @@ export class App {
     this.kinematics.wheelRevolutions += wheelIncrement; // Accumulate wheel revolutions for the CSC service.
     this.kinematics.wheelRevolutions %= 0x100000000; // Apply 32-bit wrap so the counter mirrors BLE behavior.
 
-    this.crank = { // Build the BLE-friendly crank snapshot (16-bit revolutions + timestamp in seconds).
-      timestamp: now,
-      revolutions: Math.floor(this.kinematics.crankRevolutions) & 0xffff,
+    const nextCrankRevolutions = Math.floor(this.kinematics.crankRevolutions) & 0xffff; // Snapshot the 16-bit cumulative crank count for this sample.
+    const nextWheelRevolutions = Math.floor(this.kinematics.wheelRevolutions) >>> 0; // Snapshot the 32-bit cumulative wheel count for this sample.
+
+    // Teaching note: per the CSC spec, "last event time" is the time of the
+    // most recent revolution event, not the timestamp of the packet itself.
+    if (nextCrankRevolutions !== this.crank.revolutions) {
+      this.kinematics.lastCrankEventTimestamp = now;
+    }
+    if (nextWheelRevolutions !== this.wheel.revolutions) {
+      this.kinematics.lastWheelEventTimestamp = now;
+    }
+
+    this.crank = { // Build the BLE-friendly crank snapshot (16-bit revolutions + last event timestamp in seconds).
+      timestamp: this.kinematics.lastCrankEventTimestamp,
+      revolutions: nextCrankRevolutions,
     };
 
-    this.wheel = { // Build the BLE-friendly wheel snapshot (32-bit revolutions + timestamp in seconds).
-      timestamp: now,
-      revolutions: Math.floor(this.kinematics.wheelRevolutions) >>> 0,
+    this.wheel = { // Build the BLE-friendly wheel snapshot (32-bit revolutions + last event timestamp in seconds).
+      timestamp: this.kinematics.lastWheelEventTimestamp,
+      revolutions: nextWheelRevolutions,
     };
   }
 
@@ -1137,6 +1165,7 @@ export class App {
         this.logger.error('failed to open ANT+ stick');
         return;
       }
+      this.logger.log('[gym-app] ANT+ stick detected; BLE adapter selection does not affect ANT+ USB transport');
       this.antStickClosed = false;
       const hasEventEmitter = typeof this.antStick.on === 'function';
       if (!hasEventEmitter || opened === true) {
@@ -1145,6 +1174,28 @@ export class App {
     } catch (err) {
       this.logger.error('failed to open ANT+ stick', err);
     }
+  }
+
+  getAntStatusForLogs() { // Best-effort ANT status probe used for startup diagnostics.
+    if (!this.antEnabled) {
+      return 'disabled';
+    }
+    if (!this.antStick) {
+      return 'enabled-no-stick';
+    }
+    try {
+      return this.antStick.is_present() ? 'enabled-stick-present' : 'enabled-stick-missing';
+    } catch (_error) {
+      return 'enabled-probe-error';
+    }
+  }
+
+  logRadioMap() { // Single-line adapter assignment summary to simplify support requests.
+    const bike = this.opts.bikeAdapter || 'unknown';
+    const advertise = this.serverAdapters?.length ? this.serverAdapters.join(',') : (this.opts.serverAdapter || 'unknown');
+    const hr = this.hrClient ? (this.heartRateAdapter || bike) : 'disabled';
+    const ant = this.getAntStatusForLogs();
+    this.logger.log(`[gym-app] radio map: bike-scan=${bike} ble-advertise=${advertise} hr-scan=${hr} ant=${ant}`);
   }
 
   onAntStickStartup() {
@@ -1244,9 +1295,19 @@ function resolveServerAdapters(opts, multiRoleInfo) {
     return dedupeAdapters(primary);
   }
 
-  const adapters = [...primary];
-  detected.forEach((adapter) => {
-    const normalized = normalizeAdapterName(adapter) || adapter;
+  const normalizedDetected = detected
+    .map(adapter => normalizeAdapterName(adapter) || adapter)
+    .filter(Boolean);
+  const preferredPrimary = normalizedDetected.find(adapter => adapter !== normalizedBike) || normalizedDetected[0];
+  const adapters = primary.length
+    ? [...primary]
+    : (preferredPrimary ? [preferredPrimary] : []);
+  // Teaching note: when defaults leave serverAdapter == bikeAdapter (hci0),
+  // prefer a detected non-bike adapter first so dual-radio setups split scan+advertise.
+  if (adapters.length && adapters[0] === normalizedBike && preferredPrimary && preferredPrimary !== normalizedBike) {
+    adapters.unshift(preferredPrimary);
+  }
+  normalizedDetected.forEach((normalized) => {
     if (normalized && normalized !== normalizedBike) {
       adapters.push(normalized);
     }

--- a/src/test/app/app.js
+++ b/src/test/app/app.js
@@ -85,6 +85,31 @@ test('App defaults use the GymnasticonV2 BLE advertisement name', (t) => {
   t.end();
 });
 
+test('App.integrateKinematics() keeps CSC event timestamps stable until revolutions change', (t) => {
+  const app = createTestApp();
+  try {
+    app.integrateKinematics(0, 0, 100);
+    t.equal(app.crank.revolutions, 0, 'starts with zero crank revolutions');
+    t.equal(app.wheel.revolutions, 0, 'starts with zero wheel revolutions');
+    t.equal(app.crank.timestamp, 0, 'crank event timestamp stays at zero before first revolution');
+    t.equal(app.wheel.timestamp, 0, 'wheel event timestamp stays at zero before first revolution');
+
+    app.integrateKinematics(0, 0, 110);
+    t.equal(app.crank.timestamp, 0, 'crank timestamp does not advance when cadence is zero');
+    t.equal(app.wheel.timestamp, 0, 'wheel timestamp does not advance when speed is zero');
+
+    app.integrateKinematics(120, 8, 111);
+    t.ok(app.crank.revolutions > 0, 'crank revolutions advance when cadence is positive');
+    t.ok(app.wheel.revolutions > 0, 'wheel revolutions advance when speed is positive');
+    t.equal(app.crank.timestamp, 111, 'crank timestamp moves to the sample time when a crank revolution occurs');
+    t.equal(app.wheel.timestamp, 111, 'wheel timestamp moves to the sample time when a wheel revolution occurs');
+  } finally {
+    destroyTestApp(app);
+  }
+
+  t.end();
+});
+
 test('App.run() retries cold-start bike discovery until a bike appears, then starts advertising', async (t) => {
   const logs = [];
   const sleepCalls = [];
@@ -152,4 +177,127 @@ test('App.run() retries cold-start bike discovery until a bike appears, then sta
   } finally {
     destroyTestApp(app);
   }
+});
+
+test('App.ensureBluetoothPoweredOn() reinitializes when adapter is up but probe scan fails', async (t) => {
+  const app = createTestApp();
+  let setBikeAdapterCalls = 0;
+  let reinitCalls = 0;
+  let waitCalls = 0;
+  try {
+    app.noble.state = 'unknown';
+    app.attachNobleDiagnostics = () => {};
+    app.isAdapterUp = () => true;
+    app.probeNobleScan = async () => false;
+    app.waitForNobleStateChange = async () => {
+      waitCalls += 1;
+      return 'unknown';
+    };
+    app.getFallbackAdapters = () => ['hci1'];
+    app.setBikeAdapter = () => {
+      setBikeAdapterCalls += 1;
+      return true;
+    };
+    app.reinitializeNoble = async () => {
+      reinitCalls += 1;
+      app.noble.state = 'poweredOn';
+    };
+
+    await app.ensureBluetoothPoweredOn();
+
+    t.equal(waitCalls, 0, 'does not wait for stateChange when scan probe already proved adapter is unusable');
+    t.equal(setBikeAdapterCalls, 1, 'tries a fallback adapter when available');
+    t.equal(reinitCalls, 1, 'reinitializes noble instead of continuing in degraded mode');
+  } finally {
+    destroyTestApp(app);
+  }
+});
+
+test('App.ensureBluetoothPoweredOn() returns immediately when adapter-up probe succeeds', async (t) => {
+  const app = createTestApp();
+  let reinitCalls = 0;
+  try {
+    app.noble.state = 'unknown';
+    app.attachNobleDiagnostics = () => {};
+    app.isAdapterUp = () => true;
+    app.probeNobleScan = async () => true;
+    app.reinitializeNoble = async () => {
+      reinitCalls += 1;
+    };
+
+    await app.ensureBluetoothPoweredOn();
+    t.equal(reinitCalls, 0, 'skips reinitialization when scan probe proves noble can scan');
+  } finally {
+    destroyTestApp(app);
+  }
+});
+
+test('App.startAnt() treats ANT+ as USB transport independent from BLE adapter assignment', (t) => {
+  const app = createTestApp();
+  const logs = [];
+  let started = 0;
+  try {
+    app.antEnabled = true;
+    app.logger = {
+      log: (...args) => logs.push(args.join(' ')),
+      warn: () => {},
+      error: () => {},
+    };
+    app.antStick = {
+      is_present: () => true,
+      open: () => true,
+      on() {},
+      close() {},
+    };
+    app.antServer = {
+      isRunning: false,
+      start: () => {
+        started += 1;
+      },
+      stop() {},
+    };
+
+    app.setBikeAdapter('hci1', 'test-fallback');
+    app.startAnt();
+
+    t.equal(started, 1, 'ANT+ server starts even after bike BLE adapter is reassigned');
+    t.ok(
+      logs.some(line => line.includes('BLE adapter selection does not affect ANT+ USB transport')),
+      'logs clarify that ANT+ uses separate USB transport'
+    );
+  } finally {
+    destroyTestApp(app);
+  }
+
+  t.end();
+});
+
+test('App.logRadioMap() reports bike/advertise/hr/ant assignments in one line', (t) => {
+  const app = createTestApp();
+  const logs = [];
+  try {
+    app.logger = {
+      log: (...args) => logs.push(args.join(' ')),
+      warn() {},
+      error() {},
+    };
+    app.opts.bikeAdapter = 'hci0';
+    app.serverAdapters = ['hci1'];
+    app.hrClient = null;
+    app.antEnabled = true;
+    app.antStick = { is_present: () => true };
+
+    app.logRadioMap();
+
+    const line = logs.find(entry => entry.includes('[gym-app] radio map:'));
+    t.ok(line, 'radio map log line emitted');
+    t.ok(line.includes('bike-scan=hci0'), 'bike adapter included');
+    t.ok(line.includes('ble-advertise=hci1'), 'advertising adapter included');
+    t.ok(line.includes('hr-scan=disabled'), 'hr role included');
+    t.ok(line.includes('ant=enabled-stick-present'), 'ant role included');
+  } finally {
+    destroyTestApp(app);
+  }
+
+  t.end();
 });


### PR DESCRIPTION
### Motivation

- Make BLE startup more robust when `noble` reports `unknown` but the OS adapter is up, and improve diagnostics for multi-radio and ANT+ setups.
- Ensure CSC "last event time" semantics follow the BLE spec by only advancing when a new revolution is observed.
- Prefer splitting scan and advertise roles across detected adapters on multi-radio systems and surface a compact radio assignment log line to aid troubleshooting.

### Description

- Update `ensureBluetoothPoweredOn()` to probe scanning when `hciconfig` reports the adapter is `UP`, force a `noble` reinitialization when probes fail, try fallback adapters, and avoid proceeding in a degraded mode; add better logging and early-exit when reinit recovers the adapter.
- Change kinematics bookkeeping in `integrateKinematics()` to maintain `lastCrankEventTimestamp` and `lastWheelEventTimestamp` and only advance event timestamps when cumulative revolution counters actually change, then use those timestamps in the BLE `crank` and `wheel` snapshots.
- Add ANT+ visibility and diagnostics: log ANT+ mode at startup, emit a diagnostic radio map via `logRadioMap()`, and add `getAntStatusForLogs()` to summarize ANT stick state; clarify in `startAnt()` that ANT+ is a separate USB transport.
- Improve server adapter resolution logic in `resolveServerAdapters()` to prefer a detected non-bike adapter for advertising when available and normalize/dedupe detected adapters.
- Add unit tests in `src/test/app/app.js` covering `integrateKinematics()` event-timestamp stability, `ensureBluetoothPoweredOn()` probe and reinit behavior, `startAnt()` independence from BLE adapter assignment, and `logRadioMap()` output.

### Testing

- Ran the automated unit test suite with the modified tests in `src/test/app/app.js` (including `App.integrateKinematics() keeps CSC event timestamps stable...`, `App.ensureBluetoothPoweredOn() reinitializes when adapter is up but probe scan fails`, `App.ensureBluetoothPoweredOn() returns immediately when adapter-up probe succeeds`, `App.startAnt() treats ANT+ as USB transport independent from BLE adapter assignment`, and `App.logRadioMap() reports bike/advertise/hr/ant assignments in one line`) and all tests passed.
- Existing integration/unit checks around startup, adapter fallback, and advertising were exercised via the updated tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d99c1ab7608325bddb078e5863386a)