### PR TITLE
Fix CSC event timestamps, Bluetooth reinit/fallback logic, multi-radio mapping and add GitHub release uploader

### DIFF
--- a/docs/build-sd-image.md
+++ b/docs/build-sd-image.md
@@ -53,3 +53,20 @@ You can copy the `.img.xz` (or the raw `.img` if you prefer) onto your Windows f
 cp deploy/pi-sdcard/pi-gen/deploy/Gymnasticon-modern-*.img.xz /mnt/c/Users/James/Downloads/
 ```
 You can then clone this to an an SD card to use in your Rasberry Pi.
+
+## Publish a real GitHub Release asset (not source-code zip)
+
+GitHub automatically shows **Source code (zip/tar.gz)** for every tag; those are not bootable Pi images.  
+To publish an actual flashable artifact, upload the generated `.img.xz` to the release:
+
+```bash
+cd ~/gymnasticonV2
+# Requires GitHub CLI auth (`gh auth login`)
+scripts/create-release-from-image.sh v1.5.2 bookworm
+```
+
+That command creates (or updates) the `v1.5.2` release and uploads:
+- `Gymnasticon-modern-*.img.xz`
+- `Gymnasticon-modern-*.img.xz.sha256`
+
+Use Raspberry Pi Imager or Balena Etcher to flash the `.img.xz` directly to SD/SSD.

--- a/scripts/create-release-from-image.sh
+++ b/scripts/create-release-from-image.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/create-release-from-image.sh <tag> [bookworm|buster] [--draft]
+
+Creates (or updates) a GitHub release and uploads the built Raspberry Pi image
+artifact (.img.xz + .sha256) from deploy/pi-sdcard/pi-gen/deploy.
+
+Examples:
+  scripts/create-release-from-image.sh v1.5.2 bookworm
+  scripts/create-release-from-image.sh v1.5.2 buster --draft
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+TAG="${1:-}"
+TARGET="${2:-bookworm}"
+DRAFT_FLAG="${3:-}"
+
+if [[ -z "${TAG}" ]]; then
+  echo "Missing required tag argument." >&2
+  usage
+  exit 1
+fi
+
+if [[ "${TARGET}" != "bookworm" && "${TARGET}" != "buster" ]]; then
+  echo "Target must be either 'bookworm' or 'buster'." >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required. Install it, then run: gh auth login" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY_DIR="${REPO_ROOT}/deploy/pi-sdcard/pi-gen/deploy"
+
+if [[ ! -d "${DEPLOY_DIR}" ]]; then
+  echo "Build output directory not found: ${DEPLOY_DIR}" >&2
+  echo "Build first (example): GYM_CONFIG=config.${TARGET} bash scripts/build-pi-image.sh" >&2
+  exit 1
+fi
+
+if [[ "${TARGET}" == "bookworm" ]]; then
+  IMAGE_GLOB="Gymnasticon-modern-*.img.xz"
+else
+  IMAGE_GLOB="Gymnasticon-legacy-*.img.xz"
+fi
+
+mapfile -t CANDIDATES < <(ls -1t "${DEPLOY_DIR}"/${IMAGE_GLOB} 2>/dev/null || true)
+if [[ "${#CANDIDATES[@]}" -eq 0 ]]; then
+  echo "No image found for ${TARGET} in ${DEPLOY_DIR} matching ${IMAGE_GLOB}" >&2
+  exit 1
+fi
+
+IMAGE_PATH="${CANDIDATES[0]}"
+SHA_PATH="${IMAGE_PATH}.sha256"
+
+if [[ ! -f "${SHA_PATH}" ]]; then
+  echo "Generating SHA256 checksum: ${SHA_PATH}"
+  (cd "${DEPLOY_DIR}" && sha256sum "$(basename "${IMAGE_PATH}")" > "$(basename "${SHA_PATH}")")
+fi
+
+NOTES="Raspberry Pi ${TARGET} image release.
+
+Flash the .img.xz directly with Raspberry Pi Imager or Balena Etcher."
+
+if gh release view "${TAG}" >/dev/null 2>&1; then
+  echo "Release ${TAG} already exists; uploading assets (clobber enabled)."
+  gh release upload "${TAG}" "${IMAGE_PATH}" "${SHA_PATH}" --clobber
+else
+  echo "Creating release ${TAG} and uploading assets."
+  if [[ "${DRAFT_FLAG}" == "--draft" ]]; then
+    gh release create "${TAG}" "${IMAGE_PATH}" "${SHA_PATH}" \
+      --title "${TAG}" \
+      --notes "${NOTES}" \
+      --draft
+  else
+    gh release create "${TAG}" "${IMAGE_PATH}" "${SHA_PATH}" \
+      --title "${TAG}" \
+      --notes "${NOTES}"
+  fi
+fi
+
+echo "Done. Release: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/releases/tag/${TAG}"

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -86,7 +86,9 @@ export class App {
     this.kinematics = { // Maintain cumulative wheel/crank state for CSC notifications.
       lastTimestamp: null, // Last time we integrated cadence/speed samples.
       crankRevolutions: 0, // Floating-point accumulator for crank revolutions so we can wrap at 16 bits cleanly.
-      wheelRevolutions: 0 // Floating-point accumulator for wheel revolutions (32-bit field in BLE spec).
+      wheelRevolutions: 0, // Floating-point accumulator for wheel revolutions (32-bit field in BLE spec).
+      lastCrankEventTimestamp: 0, // BLE "last crank event time" should only advance when a new crank revolution is observed.
+      lastWheelEventTimestamp: 0 // BLE "last wheel event time" should only advance when a new wheel revolution is observed.
     };
     this.crank = { timestamp: 0, revolutions: 0 }; // BLE-friendly crank snapshot (16-bit revolutions + seconds timestamp).
     this.wheel = { timestamp: 0, revolutions: 0 }; // BLE-friendly wheel snapshot (32-bit revolutions + seconds timestamp).
@@ -469,6 +471,7 @@ export class App {
       if (state === 'poweredOn') {
         return;
       }
+      let shouldReinitialize = false; // Track whether this attempt should force a noble reinit/fallback adapter hop.
       
       // Teaching note: If adapter is UP at OS level but noble reports unknown,
       // verify scan usability before proceeding; some stacks still fail scans.
@@ -479,34 +482,42 @@ export class App {
           this.logger.log('[gym-app] proceeding despite noble state mismatch (scan probe succeeded)');
           return;
         }
-        this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is up but scan probe failed; proceeding in degraded mode to avoid noble reinit bind race`);
-        return;
+        this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP but scan probe failed; reinitializing noble instead of proceeding in degraded mode`);
+        shouldReinitialize = true;
       }
       
-      this.logger.log(`[gym-app] waiting for Bluetooth adapter to become poweredOn (attempt ${attempt}/${maxAttempts}, current state: ${state})`);
-      try {
-        const nextState = await this.waitForNobleStateChange(timeoutMs);
-        if (nextState === 'poweredOn') {
-          return;
-        }
-        this.logger.log(`[gym-app] Bluetooth adapter state is ${nextState}; reinitializing noble`);
-      } catch (error) {
-        this.logger.log(`[gym-app] Bluetooth adapter state timeout after ${timeoutMs}ms; checking if adapter is up...`);
-        
-        // If adapter is up, only continue if a probe scan succeeds.
-        if (this.isAdapterUp(this.opts.bikeAdapter)) {
-          const canScan = await this.probeNobleScan(this.opts.bikeAdapter);
-          if (canScan) {
-            this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP (hciconfig confirms); proceeding despite noble state being ${state}`);
+      if (!shouldReinitialize) {
+        this.logger.log(`[gym-app] waiting for Bluetooth adapter to become poweredOn (attempt ${attempt}/${maxAttempts}, current state: ${state})`);
+        try {
+          const nextState = await this.waitForNobleStateChange(timeoutMs);
+          if (nextState === 'poweredOn') {
             return;
           }
-          this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP but scan probe failed; proceeding in degraded mode to avoid noble reinit bind race`);
-          return;
+          this.logger.log(`[gym-app] Bluetooth adapter state is ${nextState}; reinitializing noble`);
+          shouldReinitialize = true;
+        } catch (error) {
+          this.logger.log(`[gym-app] Bluetooth adapter state timeout after ${timeoutMs}ms; checking if adapter is up...`);
+          
+          // If adapter is up, only continue if a probe scan succeeds.
+          if (this.isAdapterUp(this.opts.bikeAdapter)) {
+            const canScan = await this.probeNobleScan(this.opts.bikeAdapter);
+            if (canScan) {
+              this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP (hciconfig confirms); proceeding despite noble state being ${state}`);
+              return;
+            }
+            this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is UP but scan probe failed; forcing noble reinit`);
+            shouldReinitialize = true;
+          } else {
+            this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is not responding; reinitializing noble`);
+            shouldReinitialize = true;
+          }
         }
-        
-        this.logger.log(`[gym-app] adapter ${this.opts.bikeAdapter} is not responding; reinitializing noble`);
       }
-      
+
+      if (!shouldReinitialize) {
+        continue; // Defensive: if we somehow got here without a reason to reinit, start the next probe attempt.
+      }
+
       const fallback = fallbackAdapters[fallbackIndex];
       if (fallback) {
         fallbackIndex += 1;
@@ -517,6 +528,9 @@ export class App {
         await this.reinitializeNoble(`fallback-${attempt}`);
       } else {
         await this.reinitializeNoble(`attempt-${attempt}`);
+      }
+      if (this.noble?.state === 'poweredOn') {
+        return; // No need to sleep/retry when reinit already recovered the adapter.
       }
       await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
@@ -735,6 +749,8 @@ export class App {
       const retryDelayMs = Math.max(this.minimumRetryDelayMs, Number(this.opts.connectionRetryDelay ?? sharedDefaults.connectionRetryDelay ?? 5000)); // Guarantee a sensible retry floor in production while allowing tests to override it.
       const serverAdapterLabel = this.serverAdapters?.length ? this.serverAdapters.join(',') : this.opts.serverAdapter;
       this.logger.log(`[gym-app] startup opts: bike=${this.opts.bike} defaultBike=${this.opts.defaultBike} bikeAdapter=${this.opts.bikeAdapter} serverAdapter=${serverAdapterLabel}`);
+      this.logger.log(`[gym-app] ANT+ mode: ${this.antEnabled ? 'enabled (USB ANT stick transport)' : 'disabled'}`); // ANT+ transport is independent from BLE adapter selection.
+      this.logRadioMap(); // Emit one compact "which radio does what" line for Pi troubleshooting.
 
       while (this.keepRunning) { // Keep looping until shutdown or we successfully complete the full startup sequence.
         try {
@@ -957,14 +973,26 @@ export class App {
     this.kinematics.wheelRevolutions += wheelIncrement; // Accumulate wheel revolutions for the CSC service.
     this.kinematics.wheelRevolutions %= 0x100000000; // Apply 32-bit wrap so the counter mirrors BLE behavior.
 
-    this.crank = { // Build the BLE-friendly crank snapshot (16-bit revolutions + timestamp in seconds).
-      timestamp: now,
-      revolutions: Math.floor(this.kinematics.crankRevolutions) & 0xffff,
+    const nextCrankRevolutions = Math.floor(this.kinematics.crankRevolutions) & 0xffff; // Snapshot the 16-bit cumulative crank count for this sample.
+    const nextWheelRevolutions = Math.floor(this.kinematics.wheelRevolutions) >>> 0; // Snapshot the 32-bit cumulative wheel count for this sample.
+
+    // Teaching note: per the CSC spec, "last event time" is the time of the
+    // most recent revolution event, not the timestamp of the packet itself.
+    if (nextCrankRevolutions !== this.crank.revolutions) {
+      this.kinematics.lastCrankEventTimestamp = now;
+    }
+    if (nextWheelRevolutions !== this.wheel.revolutions) {
+      this.kinematics.lastWheelEventTimestamp = now;
+    }
+
+    this.crank = { // Build the BLE-friendly crank snapshot (16-bit revolutions + last event timestamp in seconds).
+      timestamp: this.kinematics.lastCrankEventTimestamp,
+      revolutions: nextCrankRevolutions,
     };
 
-    this.wheel = { // Build the BLE-friendly wheel snapshot (32-bit revolutions + timestamp in seconds).
-      timestamp: now,
-      revolutions: Math.floor(this.kinematics.wheelRevolutions) >>> 0,
+    this.wheel = { // Build the BLE-friendly wheel snapshot (32-bit revolutions + last event timestamp in seconds).
+      timestamp: this.kinematics.lastWheelEventTimestamp,
+      revolutions: nextWheelRevolutions,
     };
   }
 
@@ -1137,6 +1165,7 @@ export class App {
         this.logger.error('failed to open ANT+ stick');
         return;
       }
+      this.logger.log('[gym-app] ANT+ stick detected; BLE adapter selection does not affect ANT+ USB transport');
       this.antStickClosed = false;
       const hasEventEmitter = typeof this.antStick.on === 'function';
       if (!hasEventEmitter || opened === true) {
@@ -1145,6 +1174,28 @@ export class App {
     } catch (err) {
       this.logger.error('failed to open ANT+ stick', err);
     }
+  }
+
+  getAntStatusForLogs() { // Best-effort ANT status probe used for startup diagnostics.
+    if (!this.antEnabled) {
+      return 'disabled';
+    }
+    if (!this.antStick) {
+      return 'enabled-no-stick';
+    }
+    try {
+      return this.antStick.is_present() ? 'enabled-stick-present' : 'enabled-stick-missing';
+    } catch (_error) {
+      return 'enabled-probe-error';
+    }
+  }
+
+  logRadioMap() { // Single-line adapter assignment summary to simplify support requests.
+    const bike = this.opts.bikeAdapter || 'unknown';
+    const advertise = this.serverAdapters?.length ? this.serverAdapters.join(',') : (this.opts.serverAdapter || 'unknown');
+    const hr = this.hrClient ? (this.heartRateAdapter || bike) : 'disabled';
+    const ant = this.getAntStatusForLogs();
+    this.logger.log(`[gym-app] radio map: bike-scan=${bike} ble-advertise=${advertise} hr-scan=${hr} ant=${ant}`);
   }
 
   onAntStickStartup() {
@@ -1244,9 +1295,19 @@ function resolveServerAdapters(opts, multiRoleInfo) {
     return dedupeAdapters(primary);
   }
 
-  const adapters = [...primary];
-  detected.forEach((adapter) => {
-    const normalized = normalizeAdapterName(adapter) || adapter;
+  const normalizedDetected = detected
+    .map(adapter => normalizeAdapterName(adapter) || adapter)
+    .filter(Boolean);
+  const preferredPrimary = normalizedDetected.find(adapter => adapter !== normalizedBike) || normalizedDetected[0];
+  const adapters = primary.length
+    ? [...primary]
+    : (preferredPrimary ? [preferredPrimary] : []);
+  // Teaching note: when defaults leave serverAdapter == bikeAdapter (hci0),
+  // prefer a detected non-bike adapter first so dual-radio setups split scan+advertise.
+  if (adapters.length && adapters[0] === normalizedBike && preferredPrimary && preferredPrimary !== normalizedBike) {
+    adapters.unshift(preferredPrimary);
+  }
+  normalizedDetected.forEach((normalized) => {
     if (normalized && normalized !== normalizedBike) {
       adapters.push(normalized);
     }

--- a/src/test/app/app.js
+++ b/src/test/app/app.js
@@ -85,6 +85,31 @@ test('App defaults use the GymnasticonV2 BLE advertisement name', (t) => {
   t.end();
 });
 
+test('App.integrateKinematics() keeps CSC event timestamps stable until revolutions change', (t) => {
+  const app = createTestApp();
+  try {
+    app.integrateKinematics(0, 0, 100);
+    t.equal(app.crank.revolutions, 0, 'starts with zero crank revolutions');
+    t.equal(app.wheel.revolutions, 0, 'starts with zero wheel revolutions');
+    t.equal(app.crank.timestamp, 0, 'crank event timestamp stays at zero before first revolution');
+    t.equal(app.wheel.timestamp, 0, 'wheel event timestamp stays at zero before first revolution');
+
+    app.integrateKinematics(0, 0, 110);
+    t.equal(app.crank.timestamp, 0, 'crank timestamp does not advance when cadence is zero');
+    t.equal(app.wheel.timestamp, 0, 'wheel timestamp does not advance when speed is zero');
+
+    app.integrateKinematics(120, 8, 111);
+    t.ok(app.crank.revolutions > 0, 'crank revolutions advance when cadence is positive');
+    t.ok(app.wheel.revolutions > 0, 'wheel revolutions advance when speed is positive');
+    t.equal(app.crank.timestamp, 111, 'crank timestamp moves to the sample time when a crank revolution occurs');
+    t.equal(app.wheel.timestamp, 111, 'wheel timestamp moves to the sample time when a wheel revolution occurs');
+  } finally {
+    destroyTestApp(app);
+  }
+
+  t.end();
+});
+
 test('App.run() retries cold-start bike discovery until a bike appears, then starts advertising', async (t) => {
   const logs = [];
   const sleepCalls = [];
@@ -152,4 +177,127 @@ test('App.run() retries cold-start bike discovery until a bike appears, then sta
   } finally {
     destroyTestApp(app);
   }
+});
+
+test('App.ensureBluetoothPoweredOn() reinitializes when adapter is up but probe scan fails', async (t) => {
+  const app = createTestApp();
+  let setBikeAdapterCalls = 0;
+  let reinitCalls = 0;
+  let waitCalls = 0;
+  try {
+    app.noble.state = 'unknown';
+    app.attachNobleDiagnostics = () => {};
+    app.isAdapterUp = () => true;
+    app.probeNobleScan = async () => false;
+    app.waitForNobleStateChange = async () => {
+      waitCalls += 1;
+      return 'unknown';
+    };
+    app.getFallbackAdapters = () => ['hci1'];
+    app.setBikeAdapter = () => {
+      setBikeAdapterCalls += 1;
+      return true;
+    };
+    app.reinitializeNoble = async () => {
+      reinitCalls += 1;
+      app.noble.state = 'poweredOn';
+    };
+
+    await app.ensureBluetoothPoweredOn();
+
+    t.equal(waitCalls, 0, 'does not wait for stateChange when scan probe already proved adapter is unusable');
+    t.equal(setBikeAdapterCalls, 1, 'tries a fallback adapter when available');
+    t.equal(reinitCalls, 1, 'reinitializes noble instead of continuing in degraded mode');
+  } finally {
+    destroyTestApp(app);
+  }
+});
+
+test('App.ensureBluetoothPoweredOn() returns immediately when adapter-up probe succeeds', async (t) => {
+  const app = createTestApp();
+  let reinitCalls = 0;
+  try {
+    app.noble.state = 'unknown';
+    app.attachNobleDiagnostics = () => {};
+    app.isAdapterUp = () => true;
+    app.probeNobleScan = async () => true;
+    app.reinitializeNoble = async () => {
+      reinitCalls += 1;
+    };
+
+    await app.ensureBluetoothPoweredOn();
+    t.equal(reinitCalls, 0, 'skips reinitialization when scan probe proves noble can scan');
+  } finally {
+    destroyTestApp(app);
+  }
+});
+
+test('App.startAnt() treats ANT+ as USB transport independent from BLE adapter assignment', (t) => {
+  const app = createTestApp();
+  const logs = [];
+  let started = 0;
+  try {
+    app.antEnabled = true;
+    app.logger = {
+      log: (...args) => logs.push(args.join(' ')),
+      warn: () => {},
+      error: () => {},
+    };
+    app.antStick = {
+      is_present: () => true,
+      open: () => true,
+      on() {},
+      close() {},
+    };
+    app.antServer = {
+      isRunning: false,
+      start: () => {
+        started += 1;
+      },
+      stop() {},
+    };
+
+    app.setBikeAdapter('hci1', 'test-fallback');
+    app.startAnt();
+
+    t.equal(started, 1, 'ANT+ server starts even after bike BLE adapter is reassigned');
+    t.ok(
+      logs.some(line => line.includes('BLE adapter selection does not affect ANT+ USB transport')),
+      'logs clarify that ANT+ uses separate USB transport'
+    );
+  } finally {
+    destroyTestApp(app);
+  }
+
+  t.end();
+});
+
+test('App.logRadioMap() reports bike/advertise/hr/ant assignments in one line', (t) => {
+  const app = createTestApp();
+  const logs = [];
+  try {
+    app.logger = {
+      log: (...args) => logs.push(args.join(' ')),
+      warn() {},
+      error() {},
+    };
+    app.opts.bikeAdapter = 'hci0';
+    app.serverAdapters = ['hci1'];
+    app.hrClient = null;
+    app.antEnabled = true;
+    app.antStick = { is_present: () => true };
+
+    app.logRadioMap();
+
+    const line = logs.find(entry => entry.includes('[gym-app] radio map:'));
+    t.ok(line, 'radio map log line emitted');
+    t.ok(line.includes('bike-scan=hci0'), 'bike adapter included');
+    t.ok(line.includes('ble-advertise=hci1'), 'advertising adapter included');
+    t.ok(line.includes('hr-scan=disabled'), 'hr role included');
+    t.ok(line.includes('ant=enabled-stick-present'), 'ant role included');
+  } finally {
+    destroyTestApp(app);
+  }
+
+  t.end();
 });


### PR DESCRIPTION
### Motivation
- Ensure CSC "last event time" follows the BLE spec by advancing only when a revolution occurs and improve telemetry accuracy. 
- Make Bluetooth adapter startup more robust by reinitializing `noble` when an adapter is UP but probe scans fail instead of proceeding in degraded mode. 
- Improve multi-radio selection and concise radio/ANT+ diagnostics to simplify troubleshooting on multi-adapter Pis. 
- Provide a supported workflow to publish built Raspberry Pi `.img.xz` artifacts as real GitHub Release assets.

### Description
- Add `scripts/create-release-from-image.sh` to create/update a GitHub release and upload the selected `Gymnasticon-*.img.xz` and `.sha256` files, and update `docs/build-sd-image.md` with usage notes for publishing real release assets. 
- Change `App.integrateKinematics()` to snapshot 16/32-bit counters, maintain `lastCrankEventTimestamp`/`lastWheelEventTimestamp`, and only advance the CSC event timestamps when revolutions change. 
- Revise `ensureBluetoothPoweredOn()` to probe scans and set a `shouldReinitialize` flag so the app will reinitialize `noble` (and try fallback adapters) when an adapter is UP but scanning fails, and to avoid unnecessary waits when a probe already determined the outcome. 
- Improve adapter resolution in `resolveServerAdapters()` to prefer a detected non-bike adapter for advertising in dual-radio setups and dedupe/normalize detected names. 
- Add ANT+ diagnostics and logging: `getAntStatusForLogs()`, `logRadioMap()`, clearer `startAnt()` log messages, and a runtime log line reporting ANT+ mode. 
- Emit a compact radio assignment summary at startup and add assorted logging and defensive checks around ANT+ stick handling and reinit flow. 
- Add unit tests in `src/test/app/app.js` covering `integrateKinematics()` timestamp behavior, `ensureBluetoothPoweredOn()` probe/reinit logic, `startAnt()` independence from BLE adapter reassignment, and `logRadioMap()` output.

### Testing
- Ran the node unit test suite which includes the updated `src/test/app/app.js` tests via the project test runner, and all tests passed. 
- Exercised the new release uploader manually by invoking `scripts/create-release-from-image.sh` against a built image in CI-like environment (authenticated `gh`), and the script successfully created/updated a release and uploaded assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d99c1ab7608325bddb078e5863386a)